### PR TITLE
fix: reset postfix modifier position if invalid

### DIFF
--- a/pkg/twmerge/create-tailwind-merge_test.go
+++ b/pkg/twmerge/create-tailwind-merge_test.go
@@ -522,6 +522,10 @@ func TestTailwindMerge(t *testing.T) {
 			in:  "hover:bg-red-500/90",
 			out: "hover:bg-red-500/90",
 		},
+		{
+			in:  "group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 group-has-[[data-sidebar=menu-action]]/menu-item:pr-6",
+			out: "group-has-[[data-sidebar=menu-action]]/menu-item:pr-6",
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/twmerge/modifier-utils.go
+++ b/pkg/twmerge/modifier-utils.go
@@ -49,6 +49,8 @@ func MakeSplitModifiers(conf *TwMergeConfig) SplitModifiersFn {
 		// fix case where there is modifier & maybePostfix which causes maybePostfix to be beyond size of baseClass!
 		if maybePostfixModPosition != -1 && maybePostfixModPosition > modifierStart {
 			maybePostfixModPosition -= modifierStart
+		} else {
+			maybePostfixModPosition = -1
 		}
 
 		return baseClass, modifiers, hasImportant, maybePostfixModPosition


### PR DESCRIPTION
# Reset postfix modifier position if invalid

## Description
This PR adds a missing else clause that ensures the postfix modifier position is properly reset when invalid, bringing the behavior in line with the original repository's implementation. The change fixes an issue where invalid positions weren't being reset to -1, which could lead to index out of bounds errors in certain cases, as demonstrated by the newly added test cases.

https://github.com/dcastil/tailwind-merge/blob/a8b2a84568a50aa01e97d2602f6ed9d9c14fe634/src/lib/parse-class-name.ts#L54C1-L57C28