### PR TITLE
Fix race in LRU

### DIFF
--- a/cmd/generate_tests/generate_tests.go
+++ b/cmd/generate_tests/generate_tests.go
@@ -91,7 +91,7 @@ func genHtml(tests []testBlock) string {
 	builder := strings.Builder{}
 	for _, block := range tests {
 		for _, test := range block.cases {
-			builder.WriteString(fmt.Sprintf("<div class='%s'></div>\n", test.in))
+			fmt.Fprintf(&builder, "<div class='%s'></div>\n", test.in)
 		}
 	}
 	return builder.String()
@@ -113,14 +113,14 @@ func TestTailwindMerge(t *testing.T) {
 	for _, block := range tests {
 		// write the description as a comment
 		if lastDescription != block.description {
-			builder.WriteString(fmt.Sprintf("\n	// %s\n", block.description))
+			fmt.Fprintf(&builder, "\n\t// %s\n", block.description)
 			lastDescription = block.description
 		}
 		for _, test := range block.cases {
-			builder.WriteString(fmt.Sprintf(`{
+			fmt.Fprintf(&builder, `{
 				in: "%s",
 				out: "%s",
-			},`, test.in, test.out))
+			},`, test.in, test.out)
 		}
 	}
 	builder.WriteString("\n	}\n")

--- a/pkg/lru/lru.go
+++ b/pkg/lru/lru.go
@@ -1,3 +1,39 @@
+// Package lru implements a thread-safe Least Recently Used (LRU) cache with O(1)
+// get, set, and eviction operations.
+//
+// The LRU cache maintains a fixed maximum capacity and automatically evicts the least
+// recently accessed items when new items are added beyond capacity. This is useful
+// for caching expensive computations where only the most recent results need to be retained.
+//
+// Concurrency Model:
+//
+// The LRU cache uses a single mutex (sync.Mutex) to protect all operations rather than
+// separate read/write locks. This design choice is critical for correctness:
+//
+//   - The cache map stores pointers to nodes, and both Get and Set operations modify
+//     the node's prev/next fields when reordering the linked list
+//
+//   - Using separate mutexes would allow one goroutine to read node pointers while another
+//     modifies them, causing data races when:
+//     1. Get() reads lru.cache[key] under cacheMutex, releases it, then modifies the node
+//     2. Concurrent Set() modifies the same node's links under listMutex
+//     3. Both access n.prev/n.next simultaneously (race condition!)
+//
+//   - A single mutex ensures atomicity of the entire "lookup and reposition" operation
+//     in Get(), and atomicity of "check existing, create node, insert, maybe evict"
+//     in Set()
+//
+// Data Structure:
+//
+// The cache uses a doubly-linked list with sentinel head/tail nodes:
+//
+//	[tail] <-> [LRU items...] <-> [MRU item] <-> [head]
+//
+//	- tail.next points to the least recently used item (eviction candidate)
+//	- head.prev points to the most recently used item
+//	- head and tail are sentinel nodes that never hold actual data
+//	- New items are inserted after head (front = most recent)
+//	- Eviction removes from tail.next (back = least recent)
 package lru
 
 import (
@@ -6,71 +42,117 @@ import (
 	"github.com/Oudwins/tailwind-merge-go/pkg/cache"
 )
 
+// node represents a single entry in the LRU cache's doubly-linked list.
+// Each node stores a key-value pair and maintains prev/next pointers for
+// O(1) removal and repositioning operations.
 type node struct {
-	key  string
-	val  string
-	prev *node
-	next *node
+	key  string // The cache key for lookup
+	val  string // The cached value
+	prev *node  // Previous node in the linked list
+	next *node  // Next node in the linked list
 }
 
+// LRU implements a concurrent-safe Least Recently Used cache with a fixed capacity.
+// Items are evicted from the tail (least recently used) when capacity is exceeded.
+// The linked list maintains most-recently-used items near head, least-recently-used
+// near tail for efficient ordering.
 type LRU struct {
-	maxCapacity int
-	capacity    int
-	cache       map[string]*node
-	head        *node
-	tail        *node
-	cacheMutex  sync.RWMutex
-	listMutex   sync.Mutex
+	maxCapacity int              // Maximum number of items allowed in the cache
+	capacity    int              // Current number of items in the cache
+	cache       map[string]*node // Hash map for O(1) key lookups to node pointers
+	head        *node            // Sentinel node marking the front (MRU position)
+	tail        *node            // Sentinel node marking the back (LRU position)
+	mutex       sync.Mutex       // Single mutex protecting all cache and list operations
 }
 
+// Get retrieves a value from the cache and marks it as most recently used.
+// If the key exists, the node is moved to the front of the list (after head)
+// so it becomes the most recently used item. If the key doesn't exist, an
+// empty string is returned. This operation is O(1).
+//
+// Thread Safety: Uses mutex.Lock() to ensure the entire lookup and list
+// repositioning is atomic, preventing races with concurrent Set operations.
 func (lru *LRU) Get(key string) string {
-	lru.cacheMutex.RLock()
+	lru.mutex.Lock()
+	defer lru.mutex.Unlock()
 	n := lru.cache[key]
 	if n == nil {
-		lru.cacheMutex.RUnlock()
 		return ""
 	}
-	lru.cacheMutex.RUnlock()
-
-	lru.listMutex.Lock()
+	// Move node to MRU position (front of list, right after head)
 	lru.remove(n)
 	lru.insertRight(n)
-	lru.listMutex.Unlock()
-
 	return n.val
 }
 
+// Set stores a key-value pair in the cache, evicting the LRU item if necessary.
+// If the key already exists, the old node is removed from its current position
+// before the new value is inserted at the MRU position. The capacity counter is
+// incremented before checking against maxCapacity, ensuring eviction happens when
+// we exceed the limit. This operation is O(1).
+//
+// Eviction Strategy:
+//   - When capacity > maxCapacity after insertion, removes tail.next (LRU item)
+//   - This maintains the invariant: capacity never exceeds maxCapacity
+//
+// Thread Safety: Uses mutex.Lock() to ensure the entire operation (check existing,
+// create node, insert, maybe evict) is atomic.
 func (lru *LRU) Set(key, value string) {
-	lru.cacheMutex.Lock()
+	lru.mutex.Lock()
+	defer lru.mutex.Unlock()
+
+	// If key exists, remove the old node before creating the new one
 	if n := lru.cache[key]; n != nil {
 		lru.remove(n)
 	}
 	n := &node{key: key, val: value}
 	lru.cache[key] = n
-	lru.cacheMutex.Unlock()
-	lru.listMutex.Lock()
-	lru.insertRight(n)
-	lru.listMutex.Unlock()
-	// evict
+	lru.insertRight(n) // Insert at MRU position (after head)
 
-	lru.listMutex.Lock()
+	// Evict LRU item if we've exceeded capacity
 	if lru.capacity > lru.maxCapacity {
 		delete(lru.cache, lru.tail.next.key)
 		lru.remove(lru.tail.next)
 	}
-	lru.listMutex.Unlock()
-
 }
 
+// insertRight adds a node at the front of the doubly-linked list (most recently used
+// position). This is called after node creation for Set operations, and after Get
+// operations to reposition accessed nodes.
+//
+// List Structure Before:
+//
+//	[tail] -> ... -> [prev=head.prev] -> [head] <- [nxt=head.next] <- ... <- [tail]
+//
+//	List Structure After:
+//
+//	[tail] -> ... -> [head] <- [n] <- [head] (n becomes head.prev, the MRU)
+//
+// This function must be called with mutex already locked by the caller.
 func (lru *LRU) insertRight(n *node) {
 	prev := lru.head.prev
 	prev.next = n
 	n.prev = prev
 	n.next = lru.head
 	lru.head.prev = n
+	lru.capacity++
 }
 
+// remove detaches a node from the doubly-linked list and resets its pointers.
+// This is used to reposition existing nodes (in Get) or remove them entirely
+// (during eviction). The node's prev/next links are set to nil to ensure
+// any concurrent access to the node cannot corrupt the list structure.
+//
+// Note: This function accesses lru.capacity, which is why it requires mutex
+// protection. A data race was occurring when Get() acquired node pointers under
+// cacheMutex but then modified them under listMutex while Set() held listMutex
+// and called remove() on the same nodes.
+//
+// This function must be called with mutex already locked by the caller.
 func (lru *LRU) remove(n *node) {
+	if n == nil {
+		return
+	}
 	prev := n.prev
 	nxt := n.next
 	prev.next = nxt
@@ -80,6 +162,14 @@ func (lru *LRU) remove(n *node) {
 	lru.capacity--
 }
 
+// Make creates a new LRU cache with the specified maximum capacity.
+// The returned cache implements the cache.ICache interface and is safe for
+// concurrent use. Items are evicted using LRU policy when capacity is exceeded.
+//
+// Initial State:
+//   - Empty cache with 0 items
+//   - head and tail sentinel nodes initialized with head.prev = tail, tail.next = head
+//   - This creates an empty list: tail <-> head
 func Make(maxCapacity int) cache.ICache {
 	head := &node{}
 	tail := &node{}

--- a/pkg/lru/lru_test.go
+++ b/pkg/lru/lru_test.go
@@ -1,0 +1,460 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// makeLRUInstance creates an LRU cache instance with the specified capacity,
+// bypassing the Make() constructor to allow direct access to internal structures
+// for testing list ordering. This is intentional for testing purposes only -
+// production code should use Make() which returns cache.ICache (hiding internals).
+//
+// List Structure After Initialization:
+//   - head.prev points to tail (empty list sentinel)
+//   - tail.next points to head (empty list sentinel)
+//   - This creates: tail <-> head (no actual data nodes between)
+func makeLRUInstance(maxCapacity int) *LRU {
+	head := &node{}
+	tail := &node{}
+	tail.next = head
+	head.prev = tail
+	return &LRU{
+		maxCapacity: maxCapacity,
+		capacity:    0,
+		cache:       make(map[string]*node),
+		head:        head,
+		tail:        tail,
+	}
+}
+
+// TestLRUGetReturnsValueForExistingKey verifies that Get retrieves the correct value
+// for a key that was previously set. This is the basic happy path for retrieval.
+func TestLRUGetReturnsValueForExistingKey(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+
+	result := lru.Get("key1")
+	if result != "value1" {
+		t.Fatalf("expected value1, got %s", result)
+	}
+}
+
+// TestLRUGetReturnsEmptyStringForMissingKey verifies that Get returns an empty
+// string when the key doesn't exist in the cache, rather than panicking or
+// returning undefined behavior.
+func TestLRUGetReturnsEmptyStringForMissingKey(t *testing.T) {
+	lru := makeLRUInstance(10)
+
+	result := lru.Get("nonexistent")
+	if result != "" {
+		t.Fatalf("expected empty string, got %s", result)
+	}
+}
+
+// TestLRUSetAddsNewKeyValuePair verifies that a new key-value pair is successfully
+// stored in the cache and can be looked up via the internal map.
+func TestLRUSetAddsNewKeyValuePair(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	if lru.cache["key1"] == nil {
+		t.Fatalf("key1 should exist in cache")
+	}
+}
+
+// TestLRUSetUpdatesExistingKeyAndMovesToFront verifies that updating an existing key
+// creates a new node (rather than mutating in place) and places it at the MRU position.
+// Creating a new node ensures proper list manipulation - the old node is removed
+// from its position and the new node is inserted at head.prev.
+func TestLRUSetUpdatesExistingKeyAndMovesToFront(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	oldNode := lru.cache["key1"]
+	lru.Set("key1", "updated_value1")
+	newNode := lru.cache["key1"]
+	if newNode == oldNode {
+		t.Fatalf("node should be recreated for updated key")
+	}
+	if newNode.val != "updated_value1" {
+		t.Fatalf("expected updated_value1, got %s", newNode.val)
+	}
+}
+
+// TestLRUEvictsLeastRecentlyUsedWhenCapacityExceeded verifies the core LRU eviction
+// policy: when capacity is exceeded, the least recently used item (oldest access)
+// is removed to make room for new items.
+//
+// Scenario:
+//  1. Set key1, key2 (fills cache to capacity 2)
+//  2. Set key3 (triggers eviction)
+//  3. key1 should be evicted (it was accessed before key2)
+//  4. key2 and key3 should remain
+func TestLRUEvictsLeastRecentlyUsedWhenCapacityExceeded(t *testing.T) {
+	lru := makeLRUInstance(2)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+	lru.Set("key3", "value3")
+	if lru.capacity != 2 {
+		t.Fatalf("capacity should be 2, got %d", lru.capacity)
+	}
+	if lru.cache["key1"] != nil {
+		t.Fatalf("key1 should have been evicted")
+	}
+	if lru.cache["key2"] == nil {
+		t.Fatalf("key2 should still exist")
+	}
+	if lru.cache["key3"] == nil {
+		t.Fatalf("key3 should exist")
+	}
+}
+
+// TestLRUDoesNotEvictWhenUnderCapacity verifies that eviction only occurs when
+// capacity is exceeded, not when we're still under the limit.
+func TestLRUDoesNotEvictWhenUnderCapacity(t *testing.T) {
+	lru := makeLRUInstance(3)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+	if lru.capacity != 2 {
+		t.Fatalf("capacity should be 2, got %d", lru.capacity)
+	}
+	if lru.cache["key1"] == nil || lru.cache["key2"] == nil {
+		t.Fatalf("both keys should exist")
+	}
+}
+
+// TestLRUWithCapacityOneEvictsOnSecondInsert verifies edge case behavior when
+// capacity is 1: only one item can exist at a time, so setting a new key
+// immediately evicts the previous one.
+func TestLRUWithCapacityOneEvictsOnSecondInsert(t *testing.T) {
+	lru := makeLRUInstance(1)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+	if lru.capacity != 1 {
+		t.Fatalf("capacity should be 1, got %d", lru.capacity)
+	}
+	if lru.cache["key1"] != nil {
+		t.Fatalf("key1 should have been evicted")
+	}
+	if lru.cache["key2"] == nil {
+		t.Fatalf("key2 should exist")
+	}
+}
+
+// TestLRUWithCapacityZeroDoesNotStoreAnything verifies that a cache with zero
+// capacity cannot store any items. The insert still happens but is immediately
+// evicted, leaving an empty cache.
+func TestLRUWithCapacityZeroDoesNotStoreAnything(t *testing.T) {
+	lru := makeLRUInstance(0)
+	lru.Set("key1", "value1")
+	if lru.capacity != 0 {
+		t.Fatalf("capacity should be 0, got %d", lru.capacity)
+	}
+	if len(lru.cache) != 0 {
+		t.Fatalf("cache should be empty")
+	}
+}
+
+// TestLRUGetMovesAccessedItemToMostRecentPosition verifies that accessing a key
+// via Get() moves it to the most-recently-used position at the front of the list.
+//
+// IMPORTANT: List ordering semantics
+//   - head.prev is the MOST recently used (front of list, insertion point)
+//   - tail.next is the LEAST recently used (back of list, eviction candidate)
+//
+// This test was previously buggy: it checked tail.next.key expecting it to be MRU,
+// but tail.next is actually the LRU. The fix checks head.prev.key for MRU.
+//
+// Sequence:
+//  1. Set key1, key2, key3 -> list: tail->key1->key2->key3->head
+//     (key3 is MRU at head.prev)
+//  2. Get key1 -> key1 is removed and reinserted at MRU position
+//     list: tail->key2->key3->key1->head
+//  3. head.prev.key should be "key1" (it's now MRU)
+func TestLRUGetMovesAccessedItemToMostRecentPosition(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+	lru.Set("key3", "value3")
+
+	// key3 is MRU (inserted last), verify head.prev points to it
+	head := lru.head.prev
+	if head.key != "key3" {
+		t.Fatalf("key3 should be most recent before access")
+	}
+
+	// Access key1 - it should now be MRU
+	lru.Get("key1")
+
+	// head.prev is MRU, verify key1 is there
+	// NOTE: Previous buggy test checked tail.next.key (which is LRU)
+	if lru.head.prev.key != "key1" {
+		t.Fatalf("key1 should be most recent after access")
+	}
+}
+
+// TestLRUSetMovesUpdatedKeyToMostRecentPosition verifies that updating a value
+// for an existing key places the new node at the MRU position.
+//
+// IMPORTANT: When Set updates an existing key, it:
+//  1. Removes the old node from the list
+//  2. Creates a new node with the updated value
+//  3. Inserts the new node at head.prev (MRU position)
+//
+// This test verifies that the new node's next pointer correctly points to head
+// (it's at the front of the list), and its prev pointer points to the node
+// that was previously at the MRU position.
+//
+// NOTE: Previous buggy test checked `firstNode.next != lru.head || secondNode.prev != lru.tail`
+// which was incorrect - after updating key1, the new node (secondNode) is at MRU,
+// so secondNode.next should equal lru.head (not firstNode.next).
+func TestLRUSetMovesUpdatedKeyToMostRecentPosition(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+
+	oldNode := lru.cache["key1"]
+
+	// Update key1 to trigger node recreation
+	lru.Set("key1", "new_value1")
+
+	newNode := lru.cache["key1"]
+	if oldNode == newNode {
+		t.Fatalf("should create new node when updating")
+	}
+
+	// After update, newNode should be at MRU position (head.prev)
+	// In a doubly-linked list with sentinel head/tail:
+	// - MRU node's next points to head (head.prev is MRU)
+	// - newNode.next should point to lru.head since it's at head.prev
+	if newNode.next != lru.head {
+		t.Fatalf("new node should be in correct list position")
+	}
+}
+
+// TestLRUMultipleGetsPreserveRecencyOrder verifies that multiple Get operations
+// correctly maintain the LRU ordering invariant.
+//
+// List positions after sequence:
+//   - After Set key1: tail->key1->head (key1 is MRU)
+//   - After Set key2: tail->key1->key2->head (key2 is MRU)
+//   - After Set key3: tail->key1->key2->key3->head (key3 is MRU)
+//   - After Get key2: tail->key1->key3->key2->head (key2 moved to MRU)
+//   - After Get key1: tail->key3->key2->key1->head (key1 moved to MRU)
+//
+// So after both Gets:
+//   - head.prev (MRU) should be key1 (most recently accessed)
+//   - tail.next (LRU) should be key3 (least recently accessed, not accessed in Gets)
+//
+// NOTE: Previous buggy test checked tail.next.key == "key1" which was incorrect.
+// tail.next is the LRU (eviction candidate), not the MRU.
+// Also: the test expected tail.next.key == "key2" but after Get(key2) then Get(key1),
+// key2 was MORE recently accessed than key3, so key3 becomes the LRU.
+func TestLRUMultipleGetsPreserveRecencyOrder(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+	lru.Set("key3", "value3")
+
+	// Access key2 first, then key1
+	lru.Get("key2")
+	lru.Get("key1")
+
+	// key1 is now MRU (most recent access)
+	// head.prev is MRU, verify key1 is there
+	if lru.head.prev.key != "key1" {
+		t.Fatalf("key1 should be most recent after access, got %s", lru.head.prev.key)
+	}
+
+	// key3 was never accessed after the Sets, so it's the LRU
+	// tail.next is LRU (eviction candidate)
+	if lru.tail.next.key != "key3" {
+		t.Fatalf("key3 should be least recent after accesses, got %s", lru.tail.next.key)
+	}
+}
+
+// TestLRUEmptyCacheOperationsWork verifies that cache operations work correctly
+// when the cache is initially empty. Getting non-existent keys should return
+// empty string without error.
+func TestLRUEmptyCacheOperationsWork(t *testing.T) {
+	lru := makeLRUInstance(10)
+	if lru.capacity != 0 {
+		t.Fatalf("empty cache should have capacity 0")
+	}
+	if lru.cache["any"] != nil {
+		t.Fatalf("empty cache should not contain any keys")
+	}
+}
+
+// TestLRURepeatedSetSameKeyDoesNotGrowCapacity verifies that repeatedly setting
+// the same key (updating in place) doesn't cause capacity to grow indefinitely.
+// Each update should remove the old node (decrementing capacity) then add the new
+// one (incrementing capacity), keeping the count stable.
+func TestLRURepeatedSetSameKeyDoesNotGrowCapacity(t *testing.T) {
+	lru := makeLRUInstance(10)
+	lru.Set("key1", "value1")
+	oldCapacity := lru.capacity
+	lru.Set("key1", "value1")
+	if lru.capacity != oldCapacity {
+		t.Fatalf("capacity should not change when setting same key multiple times")
+	}
+}
+
+// TestLRUConcurrentGetAndSetDoNotRace verifies that concurrent Get and Set operations
+// on the same keys do not cause data races.
+//
+// RACE CONDITION THAT WAS FIXED:
+// The original implementation used two separate mutexes (cacheMutex and listMutex).
+// This caused a race because:
+//  1. Goroutine A calls Get("key1"), acquires cacheMutex.RLock(), reads lru.cache["key1"]
+//  2. Goroutine A releases cacheMutex.RLock()
+//  3. Goroutine A acquires listMutex.Lock(), modifies node.prev/node.next
+//  4. Meanwhile, Goroutine B calls Set("key1", ...) which calls remove() on the SAME node
+//  5. Both goroutines access node.prev/node.next concurrently -> DATA RACE
+//
+// The fix uses a single mutex (sync.Mutex) to protect the entire operation,
+// ensuring that no two goroutines can access the same node simultaneously.
+// Note: We use sync.Mutex instead of sync.RWMutex because the critical sections
+// modify shared state (node pointers), not just read them.
+func TestLRUConcurrentGetAndSetDoNotRace(t *testing.T) {
+	t.Parallel()
+	lru := makeLRUInstance(10)
+
+	var wg sync.WaitGroup
+
+	// Launch multiple goroutines that concurrently read and write to key1
+	// This tests the race condition between Get (which repositions nodes) and Set (which removes them)
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				lru.Get("key1")
+				lru.Set("key1", "value1")
+			}
+		}()
+	}
+
+	// Launch a goroutine that writes to a different key
+	// This ensures Set operations on unrelated keys don't interfere
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 50; j++ {
+			lru.Set("key2", "value2")
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestLRUConcurrentSetsDoNotCorruptList verifies that concurrent Set operations
+// on different keys don't corrupt the linked list structure. Each goroutine
+// sets unique keys to avoid the complexity of concurrent updates to the same key.
+//
+// This test catches race conditions in:
+//   - Map insertion (lru.cache[key] = n)
+//   - List insertion (insertRight)
+//   - Capacity tracking (lru.capacity++)
+//   - Eviction logic (delete + remove when over capacity)
+func TestLRUConcurrentSetsDoNotCorruptList(t *testing.T) {
+	t.Parallel()
+	lru := makeLRUInstance(5)
+
+	var wg sync.WaitGroup
+
+	// Each goroutine sets unique keys based on index
+	for i := 0; i < 5; i++ {
+		idx := i // Capture loop variable to avoid closure issues
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				lru.Set(fmt.Sprintf("key%d", idx), "value")
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestLRUConcurrentGetsDoNotRace verifies that concurrent Get operations on the
+// same key don't cause data races. Multiple goroutines reading the same cached
+// value should all succeed without corrupting the list structure.
+//
+// This tests the safety of:
+//   - Map lookup under lock
+//   - List repositioning (remove + insertRight) for frequently accessed items
+func TestLRUConcurrentGetsDoNotRace(t *testing.T) {
+	t.Parallel()
+	lru := makeLRUInstance(10)
+	lru.Set("key", "value")
+
+	var wg sync.WaitGroup
+
+	// Multiple goroutines reading the same key repeatedly
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				lru.Get("key")
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestLRUWithMakeUsesPublicAPI verifies that the Make() constructor works correctly
+// and returns a cache that can be used through the ICache interface.
+//
+// This test ensures the public API is functional:
+//   - Make() returns a properly initialized cache
+//   - Get() and Set() work through the ICache interface
+//   - Eviction still works when capacity is exceeded
+//
+// This test covers the Make() function (previously 0% coverage) and demonstrates
+// the intended usage pattern for production code.
+func TestLRUWithMakeUsesPublicAPI(t *testing.T) {
+	lru := Make(2)
+
+	// Set and retrieve through interface
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+
+	if lru.Get("key1") != "value1" {
+		t.Fatalf("expected value1")
+	}
+	if lru.Get("key2") != "value2" {
+		t.Fatalf("expected value2")
+	}
+
+	// Trigger eviction
+	lru.Set("key3", "value3")
+
+	// key1 should be evicted (LRU)
+	if lru.Get("key1") != "" {
+		t.Fatalf("key1 should have been evicted")
+	}
+}
+
+// TestLRUGetOnEvictedKeyDoesNotPanic verifies that calling Get() after eviction
+// returns empty string without panicking. This tests the nil-safety path in
+// remove() when it's called on already-removed nodes (though this shouldn't happen
+// in normal operation, it's defensive).
+func TestLRUGetOnEvictedKeyDoesNotPanic(t *testing.T) {
+	lru := makeLRUInstance(2)
+	lru.Set("key1", "value1")
+	lru.Set("key2", "value2")
+
+	// Manually test the nil-safety of remove by accessing via cache directly
+	// (this simulates what would happen if code tried to remove nil)
+	lru.remove(nil) // Should be a no-op, not panic
+
+	// Cache should still work correctly
+	lru.Set("key3", "value3")
+	if lru.capacity != 2 {
+		t.Fatalf("capacity should be 2, got %d", lru.capacity)
+	}
+}

--- a/pkg/twmerge/merge-classlist.go
+++ b/pkg/twmerge/merge-classlist.go
@@ -62,7 +62,7 @@ func MakeMergeClassList(conf *TwMergeConfig, splitModifiers SplitModifiersFn, ge
  * - When an arbitrary variant appears, it must be preserved which modifiers are before and after it
  */
 func SortModifiers(modifiers []string) []string {
-	if modifiers == nil || len(modifiers) < 2 {
+	if len(modifiers) < 2 {
 		return modifiers
 	}
 


### PR DESCRIPTION
I encountered a race in the LRU while trying to use this with templui

with the help of a local llm, I:

- addressed the existing lint issues in the repo
- then added tests to cover the LRU
- then updated the LRU code avoid the race:


The race occurred because `Get()` and `Set()` used **two separate mutexes** but accessed the **same node pointers**:
1. `Get()` acquired `cacheMutex.RLock()`, read `lru.cache[key]` to get node pointer `n`, then **released** `cacheMutex.RUnlock()`
2. `Get()` then acquired `listMutex.Lock()` and modified `n.prev` and `n.next` in `remove()`
3. Meanwhile, `Set()` could acquire `cacheMutex.Lock()` and see the same node `n` exists, then call `remove(n)` which also modifies `n.prev`/`n.next`
4. Both goroutines accessed `n.prev`/`n.next` concurrently → **data race**

The fix: use a **single mutex** (`sync.Mutex`) to protect the entire critical section, ensuring no two goroutines can touch the same node simultaneously.
