### PR TITLE
fix: synchronise lazy build in CreateTwMerge

### DIFF
--- a/pkg/twmerge/create-tailwind-merge.go
+++ b/pkg/twmerge/create-tailwind-merge.go
@@ -2,6 +2,7 @@ package twmerge
 
 import (
 	"strings"
+	"sync"
 
 	cache "github.com/Oudwins/tailwind-merge-go/pkg/cache"
 	lru "github.com/Oudwins/tailwind-merge-go/pkg/lru"
@@ -11,7 +12,7 @@ type TwMergeFn func(args ...string) string
 
 func CreateTwMerge(config *TwMergeConfig, cache cache.ICache) TwMergeFn {
 
-	var fnToCall TwMergeFn
+	var once sync.Once
 	var splitModifiers SplitModifiersFn
 	var getClassGroupId GetClassGroupIdfn
 	var mergeClassList func(classList string) string
@@ -31,7 +32,7 @@ func CreateTwMerge(config *TwMergeConfig, cache cache.ICache) TwMergeFn {
 		return merged
 	}
 
-	init := func(args ...string) string {
+	build := func() {
 		if config == nil {
 			config = MakeDefaultConfig()
 		}
@@ -44,14 +45,11 @@ func CreateTwMerge(config *TwMergeConfig, cache cache.ICache) TwMergeFn {
 		getClassGroupId = MakeGetClassGroupId(config)
 
 		mergeClassList = MakeMergeClassList(config, splitModifiers, getClassGroupId)
-
-		fnToCall = merger
-		return fnToCall(args...)
 	}
 
-	fnToCall = init
 	return func(args ...string) string {
-		return fnToCall(args...)
+		once.Do(build)
+		return merger(args...)
 	}
 }
 

--- a/pkg/twmerge/create-tailwind-merge_test.go
+++ b/pkg/twmerge/create-tailwind-merge_test.go
@@ -3,6 +3,7 @@ package twmerge
 import (
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -576,4 +577,18 @@ func areStringsEqual(s1, s2 string) bool {
 
 	// Compare the sorted parts
 	return strings.Join(parts1, " ") == strings.Join(parts2, " ")
+}
+
+func TestConcurrentFirstCalls(t *testing.T) {
+	merge := CreateTwMerge(nil, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			merge("p-4 p-8")
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
`CreateTwMerge` builds its config, cache and closures on the first call without synchronising, so concurrent first calls race. Separate from the LRU race in #18, this file was unchanged in #20.

`sync.Once` around the build. The added test fails under `-race` on master and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple operations initialize class merging simultaneously.
  * Ensured consistent behavior during the first concurrent merge requests.

* **Tests**
  * Added coverage for concurrent first-use scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->